### PR TITLE
Minor cleanups as I review the VQA PR.

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -33,3 +33,4 @@ dependencies:
     - accelerate==0.20.3
     - datasets==2.14.6
     - minari==0.4.1
+    - webdataset==0.2.79

--- a/gato/policy/gato_policy.py
+++ b/gato/policy/gato_policy.py
@@ -336,6 +336,7 @@ class GatoPolicy(nn.Module):
                 else:
                     assert n_timesteps == discrete_action_tokens.shape[0], "number of timesteps must be the same for all modalities"
 
+            assert n_timesteps != None, "Expected n_timesteps to be set. What does your batch look like? Are you missing a required key?"
 
             separator_embeddings = torch.ones(n_timesteps, 1, self.embed_dim, device=self.device) * self.separator_token
             separator_tokens = torch.zeros(n_timesteps, 1, dtype=torch.long, device=self.device)

--- a/gato/tasks/arrow_vqa_task.py
+++ b/gato/tasks/arrow_vqa_task.py
@@ -1,0 +1,87 @@
+from collections import defaultdict
+from gato.tasks.task import Task, TaskTypeEnum
+
+import torch
+from torch import nn
+import typing
+import datasets
+import random
+from transformers import AutoTokenizer
+import torchvision
+
+to_tensor = torchvision.transforms.ToTensor()
+
+class VqaTask(Task):
+    def __init__(self, task_type: TaskTypeEnum, tokenizer_model:str, vqa_dataset: str):
+        """
+        task_type should be VQA
+        vqa_dataset is the name of a 🤗 dataset
+        """
+        super().__init__(task_type)
+        self.text_tokenizer = AutoTokenizer.from_pretrained(tokenizer_model)
+        self.dataset: datasets.DatasetDict = typing.cast(datasets.DatasetDict, datasets.load_dataset(vqa_dataset))
+
+    def sample_batch(self, batch_size):
+        self.dataset.shuffle()
+        batch_dicts = [defaultdict(list)] * batch_size
+        for key, values in self.dataset["train"][:batch_size].items():
+            for i, value in enumerate(values):
+                batch_dicts[i][key] = value
+        for d in batch_dicts:
+            # Unsqueezing to add a "batch" dimension because when gato_policy calls tokenize_input_dicts
+            # and the forward gets called on the ImageEmbedding, it expects a (B, C, H, W) shape.
+            # Alternatively, maybe we can revisit the return type of these `sample_batch` functions.
+            d["images"] = to_tensor(d["image"].resize((256, 256))).unsqueeze(0)
+        return batch_dicts
+
+    def evaluate(self, model, num_examples_to_test=50, deterministic=True, log_examples_to_output=False):
+        tokenizer = model.text_tokenizer
+        loss_fn = nn.CrossEntropyLoss()
+        total_loss = 0
+        total_tokens = 0
+
+        if num_examples_to_test > len(self.dataset['test']):
+            print(f'num_examples_to_test chosen is more than test examples, so setting it to whole test dataset.')
+            num_examples_to_test = len(self.dataset['test'])
+
+        if log_examples_to_output:
+            print(f'--- examples ---')
+        for idx in range(num_examples_to_test):
+            image = self.dataset['test'][idx]['image']
+            question = self.dataset['test'][idx]['question']
+            answer_idx = random.randint(0, len(self.dataset['test'][idx]['answers'])-1) # randomly choose an answer out of the set of answers
+            target_answer = self.dataset['test'][idx]['answers'][answer_idx]['answer']
+            target_tokens = tokenizer.encode(target_answer)
+
+            # Generate prediction
+            pred_logits, pred_answer = model.predict_answer(image, question, max_length=len(target_tokens), deterministic=deterministic)
+            if log_examples_to_output and idx%10==0:
+                print(f'Target answer: {target_answer} \n Predicted answer : {pred_answer}')
+                print("----")
+
+            # Calculate loss
+            loss = loss_fn(pred_logits, torch.tensor(target_tokens).to(model.device))
+            total_loss += loss.item()
+            total_tokens += len(target_tokens)
+        if log_examples_to_output:
+            print(f'--- examples end ---')
+
+        avg_loss = total_loss / num_examples_to_test
+        perplexity = torch.exp(torch.tensor(avg_loss))
+
+        metrics = {
+            'loss': avg_loss,
+            'perplexity': perplexity.item()
+        }
+        return metrics
+
+
+# test code
+if __name__ == '__main__':
+    # replace the following directories and files names with your directories and files
+    task = VqaTask(task_type                = TaskTypeEnum.VQA,
+                   tokenizer_model          = 'gpt2',
+                   vqa_dataset              = 'HuggingFaceM4/VQAv2')
+
+    batch = task.sample_batch(5)
+    print(batch)

--- a/gato/tasks/task.py
+++ b/gato/tasks/task.py
@@ -10,7 +10,7 @@ class TaskTypeEnum(Enum):
     # add more as we add more modalities
 
 class Task(ABC):
-    def __init__(self, task_type: str):
+    def __init__(self, task_type: TaskTypeEnum):
         if task_type not in TaskTypeEnum._value2member_map_:
             raise ValueError(f"'type' must be one of {', '.join([e.value for e in TaskTypeEnum])}")
         self.task_type = task_type

--- a/gato/tasks/task.py
+++ b/gato/tasks/task.py
@@ -11,7 +11,7 @@ class TaskTypeEnum(Enum):
 
 class Task(ABC):
     def __init__(self, task_type: TaskTypeEnum):
-        if task_type not in TaskTypeEnum._value2member_map_:
+        if not isinstance(task_type, TaskTypeEnum):
             raise ValueError(f"'type' must be one of {', '.join([e.value for e in TaskTypeEnum])}")
         self.task_type = task_type
 

--- a/gato/tasks/text_task.py
+++ b/gato/tasks/text_task.py
@@ -11,7 +11,7 @@ import torch
 import copy
 class TextTask(Task): 
        
-    def __init__(self, task_type, dataset_names:List[str], dataset_paths:List[str], context_length:int, tokenizer_model:str):
+    def __init__(self, task_type: TaskTypeEnum, dataset_names:List[str], dataset_paths:List[str], context_length:int, tokenizer_model:str):
         super().__init__(task_type)
         self.context_length = context_length
         self.text_tokenizer = AutoTokenizer.from_pretrained(tokenizer_model)

--- a/gato/tasks/vqa_task.py
+++ b/gato/tasks/vqa_task.py
@@ -1,18 +1,14 @@
 # Assume all datasets are downloaded and available from local directories
 from gato.tasks.task import Task, TaskTypeEnum
 
-import os
 from PIL import Image
-import io # need to use BytesIO
 
 import numpy as np
-import math
 import torch
-from torch.nn import functional as F
 from torch import nn
 import json
 import random
-from transformers import AutoTokenizer, GPT2Tokenizer
+from transformers import AutoTokenizer
 
 class VqaTask(Task): 
     def __init__(self, task_type: TaskTypeEnum, tokenizer_model:str,

--- a/gato/tasks/vqa_task.py
+++ b/gato/tasks/vqa_task.py
@@ -59,12 +59,14 @@ class VqaTask(Task):
                     annotations = json.load(json_file)['annotations'] 
             except:
                 print(f"{data_directory} does not have a questions json file, or it is not named as annotations.json")
+                exit(1)
 
             try:
                 with open(data_directory + questions_file, 'r') as json_file:
                     questions = json.load(json_file)['questions'] # This is a list of question IDs and the corresponding questions
             except:
                 print(f"{data_directory} does not have an annotations json file, or it is not named as questions.json")
+                exit(1)
 
             assert len(annotations) == len(questions), "Number of annotations must be equal to number of questions" 
         

--- a/gato/tasks/vqa_task.py
+++ b/gato/tasks/vqa_task.py
@@ -148,7 +148,8 @@ class VqaTask(Task):
 # test code
 if __name__ == '__main__':
     # replace the following directories and files names with your directories and files
-    task = VqaTask(task_type                = 'vqa', 
+    task = VqaTask(task_type                = TaskTypeEnum.VQA,
+                   tokenizer_model          = 'gpt2',
                    vqa_dataset              = '/home/<user name>/Git/NEKO/VQA_Data/',
                    train_data               = ['train2014'], 
                    test_data                = ['val2014'],

--- a/gato/training/trainer.py
+++ b/gato/training/trainer.py
@@ -165,7 +165,7 @@ class Trainer:
             control_batch_dicts = self.sample_control_batch(control_batch_size)
 
         # Combine the batches
-        combined_batch_dicts = text_batch_dicts + caption_batch_dicts + vqa_batch_dicts+ control_batch_dicts
+        combined_batch_dicts = text_batch_dicts + caption_batch_dicts + vqa_batch_dicts + control_batch_dicts
 
 
         logs['time/sample_batch'] = time.time() - start_time
@@ -185,22 +185,22 @@ class Trainer:
 
     def sample_text_batch(self, batch_size):
         batch_dicts = []
-        text_tasks = [t for t in self.tasks if t.task_type == TaskTypeEnum.TEXT.value]
+        text_tasks = [t for t in self.tasks if t.task_type == TaskTypeEnum.TEXT]
         for i,task in enumerate (text_tasks):
             batch_dicts.extend(task.sample_batch(batch_size))
         return batch_dicts
 
     def sample_caption_batch(self, batch_size):
         batch_dicts = []
-        caption_tasks = [t for t in self.tasks if t.task_type == TaskTypeEnum.CAPTION.value]
+        caption_tasks = [t for t in self.tasks if t.task_type == TaskTypeEnum.CAPTION]
         for i,task in enumerate (caption_tasks):
             batch_dicts.extend(task.sample_batch(batch_size))
         return batch_dicts
     
     def sample_vqa_batch(self, batch_size):
         batch_dicts = []
-        vqa_tasks = [t for t in self.tasks if t.task_type == TaskTypeEnum.VQA.value]
-        for i,task in enumerate (vqa_tasks):
+        vqa_tasks = [t for t in self.tasks if t.task_type == TaskTypeEnum.VQA]
+        for task in vqa_tasks:
             batch_dicts.extend(task.sample_batch(batch_size))
         return batch_dicts
 
@@ -208,7 +208,7 @@ class Trainer:
         batch_dicts = []
 
         sampled_task_indices = []
-        control_tasks = [t for t in self.tasks if t.task_type == TaskTypeEnum.CONTROL.value]
+        control_tasks = [t for t in self.tasks if t.task_type == TaskTypeEnum.CONTROL]
         n_tasks = len(control_tasks)
         while len(sampled_task_indices) < batch_size:
             max_n = min(n_tasks, batch_size - len(sampled_task_indices))

--- a/train.py
+++ b/train.py
@@ -20,7 +20,7 @@ from gato.training.schedulers import get_linear_warmup_cosine_decay_scheduler
 from gato.tasks.control_task import ControlTask
 from gato.tasks.text_task import TextTask
 from gato.tasks.caption_task import CaptionTask
-from gato.tasks.vqa_task import VqaTask
+from gato.tasks.arrow_vqa_task import VqaTask
 from gato.tasks.task import TaskTypeEnum
 
 
@@ -38,7 +38,7 @@ def main(args):
     envs, control_datasets = load_envs(args.control_datasets) # Load Minari datasets and corresponding Gym environments
     for env, dataset in zip(envs, control_datasets):
         task = ControlTask(
-            TaskTypeEnum.CONTROL.value,
+            TaskTypeEnum.CONTROL,
             env.unwrapped.spec.id,
             env,
             dataset,
@@ -52,24 +52,20 @@ def main(args):
     
     if len(args.text_datasets) > 0:
         # add text datasets
-        tasks.append(TextTask(TaskTypeEnum.TEXT.value, args.text_datasets, args.text_datasets_paths, args.sequence_length, tokenizer_model=args.tokenizer_model_name)) 
+        tasks.append(TextTask(TaskTypeEnum.TEXT, args.text_datasets, args.text_datasets_paths, args.sequence_length, tokenizer_model=args.tokenizer_model_name))
     else:
         assert (args.text_prop == 0), 'text_prop must be 0 if no text datasets are specified'
  
     if len(args.caption_dataset) > 0:
         # add caption datasets
-        tasks.append(CaptionTask(TaskTypeEnum.CAPTION.value, args.tokenizer_model_name, 
+        tasks.append(CaptionTask(TaskTypeEnum.CAPTION, args.tokenizer_model_name,
                                  args.caption_dataset, args.caption_train_data, args.caption_test_data, args.test_data_prop))
     else:
         assert (args.caption_prop == 0), 'caption_prop must be 0 if no text datasets are specified'
     
     if len(args.vqa_dataset) > 0:
         # add vqa datasets
-        tasks.append(VqaTask(TaskTypeEnum.VQA.value, args.tokenizer_model_name, 
-                             args.vqa_dataset, args.vqa_train_data, args.vqa_test_data, 
-                             args.train_img_name_prefix, args.train_img_file_name_len, 
-                             args.test_img_name_prefix, args.test_img_file_name_len, 
-                             args.questions_file, args.annotations_file))
+        tasks.append(VqaTask(TaskTypeEnum.VQA, args.tokenizer_model_name, args.vqa_dataset))
     else:
         assert (args.vqa_prop == 0), 'vqa_prop must be 0 if no text datasets are specified'
 

--- a/train.sh
+++ b/train.sh
@@ -1,0 +1,14 @@
+python -m pdb train.py \
+  --embed_dim=768 \
+  --layers=6 \
+  --heads=24 \
+  --training_steps=1000 \
+  --log_eval_freq=10 \
+  --warmup_steps=10 \
+  --batch_size=4 -k=240 \
+  --eval_episodes=10 \
+  --sequence_length=1024 \
+  --activation_fn=gelu \
+  --save_model \
+  --vqa_prop=1.0 \
+  --vqa_dataset='HuggingFaceM4/VQAv2'


### PR DESCRIPTION
Just using this PR as a place to store the changes that I find convenient as I familiarize myself with the project and review an existing PR.

When I was looking for a dataset to test this with, 🤗 seemed like simple way to get a good dataset, but it was a completely different format than the directory structure that the existing PR expects. It looks like moving to 🤗 datasets (if we end up wanting to) won't be a huge lines-of-code change, and it eliminates the need for a lot of kwarg options and similar boilerplate. Maybe more importantly, I think it might [provide a performance benefit](https://huggingface.co/docs/datasets/index):

> Backed by the Apache Arrow format, process large datasets with zero-copy reads without any memory constraints for optimal speed and efficiency.

At the time I'm writing this, there are some type-related changes in this diff. For example:

```
-    def __init__(self, task_type: str):
-        if task_type not in TaskTypeEnum._value2member_map_:
+    def __init__(self, task_type: TaskTypeEnum):
+        if not isinstance(task_type, TaskTypeEnum):
```

Declaring a `task_type` as a `str` loses the benefit of having a `TaskTypeEnum` since a `str` can be any string, whereas a `TaskTypeEnum` _must_ be one of the valid enums. I think I'll make a separate PR into `master` with just these type changes. It might touch a lot of files, so I expect it's going to create a lot of conflicts with the existing open PRs. I'll make updates to those PRs as well, fixing any conflicts.