### PR TITLE
Update TaskType references to use enum, not str

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -49,7 +49,7 @@ def main(args):
     env_names = []
     for env, dataset in zip(envs, datasets):
         task = ControlTask(
-            TaskTypeEnum.CONTROL.value,
+            TaskTypeEnum.CONTROL,
             env.unwrapped.spec.id, 
             env, 
             dataset,

--- a/eval.py
+++ b/eval.py
@@ -3,7 +3,6 @@ import os
 import json
 import time
 
-import numpy as np
 import torch
 
 from peft import LoraConfig, TaskType, get_peft_model
@@ -13,9 +12,7 @@ from accelerate import Accelerator
 from gato.utils.utils import DotDict
 from gato.policy.gato_policy import GatoPolicy
 from gato.envs.setup_env import load_envs
-from gato.training.trainer import Trainer
 from gato.tasks.control_task import ControlTask
-from gato.tasks.task import TaskTypeEnum
 
 
 def main(args):
@@ -49,8 +46,7 @@ def main(args):
     env_names = []
     for env, dataset in zip(envs, datasets):
         task = ControlTask(
-            TaskTypeEnum.CONTROL,
-            env.unwrapped.spec.id, 
+            env.unwrapped.spec.id,
             env, 
             dataset,
             args = eval_args,

--- a/gato/policy/gato_policy.py
+++ b/gato/policy/gato_policy.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional
 import torch
 import torch.nn as nn
 
@@ -10,7 +11,9 @@ from transformers import AutoTokenizer
 from gato.transformers import GPT2Model
 from gato.policy.embeddings import ImageEmbedding
 from gato.policy.input_tokenizers import ContinuousTokenizer
-from gato.tasks.control_task import ControlTask
+
+if TYPE_CHECKING:
+    from gato.tasks.control_task import ControlTask
 
 class GatoPolicy(nn.Module):
     def __init__(
@@ -147,7 +150,7 @@ class GatoPolicy(nn.Module):
 
 
     # predicts next token (for each input token)
-    def forward(self, inputs: list = None, compute_loss=False, **kwargs):
+    def forward(self, inputs: Optional[list]=None, compute_loss=False, **kwargs):
         # tokenize inputs
         if inputs is not None:
             token_embeddings, tokens, token_target_masks, token_masks = self.tokenize_input_dicts(inputs)

--- a/gato/policy/gato_policy.py
+++ b/gato/policy/gato_policy.py
@@ -1,7 +1,6 @@
+from typing import Optional
 import torch
 import torch.nn as nn
-import numpy as np
-from einops import rearrange
 
 import gymnasium as gym
 import transformers
@@ -12,8 +11,6 @@ from gato.transformers import GPT2Model
 from gato.policy.embeddings import ImageEmbedding
 from gato.policy.input_tokenizers import ContinuousTokenizer
 from gato.tasks.control_task import ControlTask
-from torch.nn import functional as F
-from copy import deepcopy
 
 class GatoPolicy(nn.Module):
     def __init__(
@@ -41,7 +38,7 @@ class GatoPolicy(nn.Module):
         use_pos_encoding: bool = True,
         use_patch_pos_encoding: bool = True,
 
-        pretrained_lm: str = None, # Optional, name of pretrained language model to use
+        pretrained_lm: Optional[str] = None, # Optional, name of pretrained language model to use
         flash: bool = False, # TODO verify correctness
         tokenizer_model_name: str = 'gpt2',
         pad_seq: bool = False

--- a/gato/tasks/control_task.py
+++ b/gato/tasks/control_task.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
 import gymnasium as gym
 import numpy as np
 import torch
 import minari
 from minari.dataset.minari_dataset import EpisodeData
+from gato.tasks.task import Task
 
-from gato.tasks.task import Task, TaskTypeEnum
+if TYPE_CHECKING:
+    from gato.policy.gato_policy import GatoPolicy
 
 supported_spaces = [
     gym.spaces.Box,
@@ -23,8 +28,7 @@ def tokens_per_space(space):
 class ControlTask(Task):
     def __init__(
             self,
-            task_type: TaskTypeEnum,
-            env_name: str, 
+            env_name: str,
             env: gym.Env, 
             dataset: minari.MinariDataset, 
             context_len: int,
@@ -33,7 +37,7 @@ class ControlTask(Task):
             share_prompt_episodes=True,
             top_k_prompting=None
         ):
-        super().__init__(task_type)
+        super().__init__()
         self.name = env_name
         self.is_atari = 'ALE' in env_name
         self.env = env
@@ -99,7 +103,7 @@ class ControlTask(Task):
             self.top_ids = None
 
     
-    def evaluate(self, model, n_iterations, deterministic=True, promptless_eval=False):
+    def evaluate(self, model: GatoPolicy, n_iterations, deterministic=True, promptless_eval=False):
         # serial evaluation
         returns = []
         clipped_returns = []

--- a/gato/tasks/task.py
+++ b/gato/tasks/task.py
@@ -8,8 +8,8 @@ class TaskTypeEnum(Enum):
     # add more as we add more modalities
 
 class Task(ABC):
-    def __init__(self, task_type: str):
-        if task_type not in TaskTypeEnum._value2member_map_:
+    def __init__(self, task_type: TaskTypeEnum):
+        if not isinstance(task_type, TaskTypeEnum):
             raise ValueError(f"'type' must be one of {', '.join([e.value for e in TaskTypeEnum])}")
         self.task_type = task_type
 

--- a/gato/tasks/task.py
+++ b/gato/tasks/task.py
@@ -1,20 +1,8 @@
 from abc import ABC
-from inspect import signature
-from enum import Enum
-
-class TaskTypeEnum(Enum):
-    CONTROL = "control"
-    TEXT = "text"
-    # add more as we add more modalities
 
 class Task(ABC):
-    def __init__(self, task_type: TaskTypeEnum):
-        if not isinstance(task_type, TaskTypeEnum):
-            raise ValueError(f"'type' must be one of {', '.join([e.value for e in TaskTypeEnum])}")
-        self.task_type = task_type
-
     def sample_batch(self):
-        pass
+        raise NotImplementedError()
 
-    def evaluate(self, model):
-        pass        
+    def evaluate(self):
+        raise NotImplementedError()

--- a/gato/tasks/text_task.py
+++ b/gato/tasks/text_task.py
@@ -1,18 +1,20 @@
+from __future__ import annotations
 # supports dataset in huggingface datasets library for now
 from datasets import load_dataset, concatenate_datasets
-from gato.tasks.task import Task, TaskTypeEnum
+from gato.tasks.task import Task
 import numpy as np
-import math
-from torch.nn import functional as F
 from torch import nn
-from typing import List,Dict
-from transformers import AutoTokenizer, GPT2Tokenizer
+from typing import TYPE_CHECKING, List,Dict
+from transformers import AutoTokenizer
 import torch
 import copy
+
+if TYPE_CHECKING:
+    from gato.policy.gato_policy import GatoPolicy
+
 class TextTask(Task): 
-       
-    def __init__(self, task_type, dataset_names:List[str], dataset_paths:List[str], context_length:int, tokenizer_model:str):
-        super().__init__(task_type)
+    def __init__(self, dataset_names:List[str], dataset_paths:List[str], context_length:int, tokenizer_model:str):
+        super().__init__()
         self.context_length = context_length
         self.text_tokenizer = AutoTokenizer.from_pretrained(tokenizer_model)
         text_datasets_list = []
@@ -57,7 +59,7 @@ class TextTask(Task):
         
         return batch_dicts
         
-    def evaluate(self, model, num_examples_to_test=50, deterministic=True, log_examples_to_output=False):
+    def evaluate(self, model: GatoPolicy, num_examples_to_test=50, deterministic=True, log_examples_to_output=False):
         tokenizer = model.text_tokenizer
         loss_fn = nn.CrossEntropyLoss()
         total_loss = 0

--- a/gato/training/trainer.py
+++ b/gato/training/trainer.py
@@ -79,12 +79,12 @@ class Trainer:
         with torch.no_grad():
             for task in self.tasks:
                 eval_logs = {}
-                if task.task_type == TaskTypeEnum.CONTROL.value:
+                if task.task_type == TaskTypeEnum.CONTROL:
                     if self.args.eval_episodes > 0 :
                         eval_logs = task.evaluate(self.model, n_iterations=self.args.eval_episodes, deterministic=self.deterministic, promptless_eval=self.args.promptless_eval)
                     for k, v in eval_logs.items():
                         logs[f'evaluation/{task.name}/{k}'] = v
-                elif task.task_type == TaskTypeEnum.TEXT.value:
+                elif task.task_type == TaskTypeEnum.TEXT:
                     eval_logs = task.evaluate(self.model, num_examples_to_test=self.args.eval_text_num_examples, deterministic=self.deterministic, log_examples_to_output=self.args.eval_text_log_examples)
                     for k, v in eval_logs.items():
                         logs[f'evaluation/text/{k}'] = v
@@ -149,7 +149,7 @@ class Trainer:
 
     def sample_text_batch(self, batch_size):
         batch_dicts = []
-        text_tasks = [t for t in self.tasks if t.task_type == TaskTypeEnum.TEXT.value]
+        text_tasks = [t for t in self.tasks if t.task_type == TaskTypeEnum.TEXT]
         for i,task in enumerate (text_tasks):
             batch_dicts.extend(task.sample_batch(batch_size))
         return batch_dicts
@@ -158,7 +158,7 @@ class Trainer:
         batch_dicts = []
 
         sampled_task_indices = []
-        control_tasks = [t for t in self.tasks if t.task_type == TaskTypeEnum.CONTROL.value]
+        control_tasks = [t for t in self.tasks if t.task_type == TaskTypeEnum.CONTROL]
         n_tasks = len(control_tasks)
         while len(sampled_task_indices) < batch_size:
             max_n = min(n_tasks, batch_size - len(sampled_task_indices))

--- a/train.py
+++ b/train.py
@@ -9,7 +9,6 @@ from peft import LoraConfig, TaskType, get_peft_model
 from accelerate import Accelerator
 from accelerate import DistributedDataParallelKwargs
 
-import transformers
 
 from gato.utils.utils import DotDict
 from gato.policy.gato_policy import GatoPolicy
@@ -18,7 +17,6 @@ from gato.training.trainer import Trainer
 from gato.training.schedulers import get_linear_warmup_cosine_decay_scheduler
 from gato.tasks.control_task import ControlTask
 from gato.tasks.text_task import TextTask
-from gato.tasks.task import TaskTypeEnum
 
 
 def main(args):
@@ -35,7 +33,6 @@ def main(args):
     envs, control_datasets = load_envs(args.control_datasets) # Load Minari datasets and corresponding Gym environments
     for env, dataset in zip(envs, control_datasets):
         task = ControlTask(
-            TaskTypeEnum.CONTROL,
             env.unwrapped.spec.id,
             env,
             dataset,
@@ -49,7 +46,7 @@ def main(args):
     
     if len(args.text_datasets) > 0:
         # add text datasets
-        tasks.append(TextTask(TaskTypeEnum.TEXT, args.text_datasets, args.text_datasets_paths, args.sequence_length, tokenizer_model=args.tokenizer_model_name))
+        tasks.append(TextTask(args.text_datasets, args.text_datasets_paths, args.sequence_length, tokenizer_model=args.tokenizer_model_name))
     else:
         assert (args.text_prop == 0), 'text_prop must be 0 if no text datasets are specified'
 

--- a/train.py
+++ b/train.py
@@ -35,7 +35,7 @@ def main(args):
     envs, control_datasets = load_envs(args.control_datasets) # Load Minari datasets and corresponding Gym environments
     for env, dataset in zip(envs, control_datasets):
         task = ControlTask(
-            TaskTypeEnum.CONTROL.value,
+            TaskTypeEnum.CONTROL,
             env.unwrapped.spec.id,
             env,
             dataset,
@@ -49,7 +49,7 @@ def main(args):
     
     if len(args.text_datasets) > 0:
         # add text datasets
-        tasks.append(TextTask(TaskTypeEnum.TEXT.value, args.text_datasets, args.text_datasets_paths, args.sequence_length, tokenizer_model=args.tokenizer_model_name)) 
+        tasks.append(TextTask(TaskTypeEnum.TEXT, args.text_datasets, args.text_datasets_paths, args.sequence_length, tokenizer_model=args.tokenizer_model_name))
     else:
         assert (args.text_prop == 0), 'text_prop must be 0 if no text datasets are specified'
 


### PR DESCRIPTION
`<Enum>.value` has type `str`, which could be anything. This PR updates all references of type TaskTypeEnum to be checks against the Enum itself rather than it's value.