### PR TITLE
Fix version dependency issue #54

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.pt
 args.json
 wandb/
+*.egg-info

--- a/env.yml
+++ b/env.yml
@@ -1,4 +1,4 @@
-name: gato-control
+name: neko
 channels:
   - pytorch
   - nvidia

--- a/env.yml
+++ b/env.yml
@@ -32,4 +32,5 @@ dependencies:
     - peft==0.3.0
     - accelerate==0.20.3
     - datasets==2.14.6
-    - minari==0.4.1
+    - minari==0.4.2
+    - typing_extensions>=4.5.0


### PR DESCRIPTION
Some of the HuggingFace libraries require typing_extensions >= 4.5.0 but Minari listed it as an exact 4.4.0 requirement. Minari version 0.4.2 updates that exact requirement to be a >= requirement.

https://github.com/ManifoldRG/NEKO/issues/54