### PR TITLE
Enable eval.py to work on text datasets

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -49,7 +49,6 @@ def main(args):
     env_names = []
     for env, dataset in zip(envs, datasets):
         task = ControlTask(
-            TaskTypeEnum.CONTROL.value,
             env.unwrapped.spec.id, 
             env, 
             dataset,

--- a/eval.py
+++ b/eval.py
@@ -13,8 +13,8 @@ from accelerate import Accelerator
 from gato.utils.utils import DotDict
 from gato.policy.gato_policy import GatoPolicy
 from gato.envs.setup_env import load_envs
-from gato.training.trainer import Trainer
 from gato.tasks.control_task import ControlTask
+from gato.tasks.text_task import TextTask
 from gato.tasks.task import TaskTypeEnum
 
 
@@ -62,6 +62,10 @@ def main(args):
         tasks.append(task)
     print('Evaluating on envs:', env_names)
 
+    if len(args.text_datasets) > 0:
+        # add text datasets
+        tasks.append(TextTask(args.text_datasets, args.text_datasets_paths, args.sequence_length, tokenizer_model=args.tokenizer_model_name)) 
+
     model = GatoPolicy(
         device=eval_args.device,
         embed_dim=eval_args.embed_dim,
@@ -100,12 +104,17 @@ def main(args):
     model.eval()
     eval_start = time.time()
     
-    # loop over eval for each env
+    # loop over eval for each task
     with torch.no_grad():
         for task in tasks:
-            eval_logs = task.evaluate(model, n_iterations=eval_args.eval_episodes, deterministic=eval_args.eval_mode == 'deterministic', promptless_eval=eval_args.promptless_eval)
-            for k, v in eval_logs.items():
-                logs[f'evaluation/{task.name}/{k}'] = v
+            if task.task_type == TaskTypeEnum.CONTROL.value:
+                eval_logs = task.evaluate(model, n_iterations=eval_args.eval_episodes, deterministic=eval_args.eval_mode == 'deterministic', promptless_eval=eval_args.promptless_eval)
+                for k, v in eval_logs.items():
+                    logs[f'evaluation/{task.name}/{k}'] = v
+            elif task.task_type == TaskTypeEnum.TEXT.value:
+                eval_logs = task.evaluate(model, eval_args.eval_text_num_examples, deterministic=eval_args.eval_mode == 'deterministic', log_examples_to_output=eval_args.eval_text_log_examples)
+                for k, v in eval_logs.items():
+                    logs[f'evaluation/text/{k}'] = v
 
     logs['time/evaluation'] = time.time() - eval_start
 
@@ -123,14 +132,24 @@ if __name__ == '__main__':
     parser.add_argument('--cpu', default=False, action='store_true')
 
     # evaluation
-    parser.add_argument('--eval_episodes', type=int, default=None)
     parser.add_argument('--eval_mode', type=str, default='deterministic', choices=['deterministic', 'stochastic'])
+    
+    # evaluation - control
+    parser.add_argument('--eval_episodes', type=int, default=None)
     parser.add_argument('--promptless_eval', action='store_true', default=None)
     parser.add_argument('--top_k', type=int, default=None) # sample prompts only from top k episodes
     parser.add_argument('--render', action='store_true', default=None)
+    
+    # evaluation - text
+    parser.add_argument('--sequence_length', '-k', type=int, default=1024) # number of tokens in seq
+    parser.add_argument('--tokenizer_model_name', type=str, default='gpt2')
+    parser.add_argument('--eval_text_num_examples', type=int, default=100)
+    parser.add_argument('--eval_text_log_examples', action='store_true', default=False)
 
     # datasets / envs
     parser.add_argument('--control_datasets', type=str, nargs='+', default=None)
+    parser.add_argument('--text_datasets', type=str, nargs='+', default=[]) # ['wikitext-2-v1']
+    parser.add_argument('--text_datasets_paths', type=str, nargs='+', default=[]) # ['wikitext']
 
     args = parser.parse_args()
     args = DotDict(vars(args))

--- a/gato/tasks/control_task.py
+++ b/gato/tasks/control_task.py
@@ -23,7 +23,6 @@ def tokens_per_space(space):
 class ControlTask(Task):
     def __init__(
             self,
-            task_type: TaskTypeEnum,
             env_name: str, 
             env: gym.Env, 
             dataset: minari.MinariDataset, 
@@ -33,7 +32,7 @@ class ControlTask(Task):
             share_prompt_episodes=True,
             top_k_prompting=None
         ):
-        super().__init__(task_type)
+        super().__init__(TaskTypeEnum.CONTROL.value)
         self.name = env_name
         self.is_atari = 'ALE' in env_name
         self.env = env

--- a/gato/tasks/text_task.py
+++ b/gato/tasks/text_task.py
@@ -11,8 +11,8 @@ import torch
 import copy
 class TextTask(Task): 
        
-    def __init__(self, task_type, dataset_names:List[str], dataset_paths:List[str], context_length:int, tokenizer_model:str):
-        super().__init__(task_type)
+    def __init__(self, dataset_names:List[str], dataset_paths:List[str], context_length:int, tokenizer_model:str):
+        super().__init__(TaskTypeEnum.TEXT.value)
         self.context_length = context_length
         self.text_tokenizer = AutoTokenizer.from_pretrained(tokenizer_model)
         text_datasets_list = []

--- a/train.py
+++ b/train.py
@@ -35,7 +35,6 @@ def main(args):
     envs, control_datasets = load_envs(args.control_datasets) # Load Minari datasets and corresponding Gym environments
     for env, dataset in zip(envs, control_datasets):
         task = ControlTask(
-            TaskTypeEnum.CONTROL.value,
             env.unwrapped.spec.id,
             env,
             dataset,
@@ -49,7 +48,7 @@ def main(args):
     
     if len(args.text_datasets) > 0:
         # add text datasets
-        tasks.append(TextTask(TaskTypeEnum.TEXT.value, args.text_datasets, args.text_datasets_paths, args.sequence_length, tokenizer_model=args.tokenizer_model_name)) 
+        tasks.append(TextTask(args.text_datasets, args.text_datasets_paths, args.sequence_length, tokenizer_model=args.tokenizer_model_name)) 
     else:
         assert (args.text_prop == 0), 'text_prop must be 0 if no text datasets are specified'
 


### PR DESCRIPTION
This pull request has changes to enable evaluation on text data as mentioned in https://github.com/ManifoldRG/NEKO/issues/23

Command I used to train a sample model
```bash
python train.py --embed_dim=192 --layers=3 --heads=6 --training_steps=1000 --log_eval_freq=10 --warmup_steps=20 --batch_size=16 --sequence_length=1024 --eval_episodes=10 --activation_fn=gelu --save_model --save_mode=checkpoint --text_prop=1.0 --eval_text_log_examples --text_datasets=wikitext-2-v1 --text_datasets_paths=wikitext --use_wandb --disable_cosine_decay
``` 
To test evaluating the model on text, I used
```bash
python eval.py --model_path models/neko-gato-922430/checkpoint_60.pt --text_datasets wikitext-2-v1 --text_datasets_paths wikitext  
```

Output:
```bash
Evaluating on envs: []
Num of examples to test : 100 | Actual batch size of test data : 71
================================================================================
Evaluation results:
evaluation/text/loss: 7.554824483226723
evaluation/text/perplexity: 1909.9346923828125
time/evaluation: 22.53506851196289
```

I have also tweaked ```ControlTask``` and ```TextTask``` classes slightly. These classes need not be given ```TaskTypeEnum``` value, they can be hard-coded within the class itself.