### PR TITLE
Changed saved model name from an ID to a timestamp

### DIFF
--- a/train.py
+++ b/train.py
@@ -1,6 +1,7 @@
 import argparse
 import random
 import os
+from datetime import datetime
 
 import wandb
 import torch
@@ -27,8 +28,8 @@ def main(args):
     device = accelerator.device
     args.device = accelerator.device
 
-    exp_id = random.randint(int(1e5), int(1e6) - 1)
-    exp_name = f'neko-gato-{exp_id}'
+    exp_date = datetime.now().strftime('%y-%m-%d_%H-%M-%S')
+    exp_name = f'neko-gato_{exp_date}'
 
     tasks = []
     # add control datasets and env


### PR DESCRIPTION
From issue #69, I changed the exp_name of the saved model during training to have a time stamp of the format %y-%m-%d_%H-%M-%S (example: neko-gato_24-01-13_17-37-27) using the built in datetime library. 