### PR TITLE
Fix the deprecation of the usage Accelerator, add code for new way

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -30,7 +30,7 @@ dependencies:
     - gymnasium[all]==0.29.0
     - gymnasium[accept-rom-license]
     - peft==0.3.0
-    - accelerate==0.20.3
+    - accelerate==0.30.0
     - datasets==2.14.6
     - minari==0.4.2
     - typing_extensions>=4.5.0

--- a/train.py
+++ b/train.py
@@ -8,6 +8,7 @@ import torch
 from peft import LoraConfig, TaskType, get_peft_model
 from accelerate import Accelerator
 from accelerate import DistributedDataParallelKwargs
+from accelerate import DataLoaderConfiguration
 
 from gato.utils.typed_argparser import TypedArgumentParser
 from gato.training.arguments import TrainingArgs
@@ -23,7 +24,8 @@ from gato.tasks.vqa_task import VqaTask
 
 def main(args):
     ddp_kwargs = DistributedDataParallelKwargs(find_unused_parameters=True)
-    accelerator = Accelerator(cpu=args.cpu, mixed_precision=args.mixed_precision, split_batches=True, gradient_accumulation_steps=args.gradient_accumulation_steps, kwargs_handlers=[ddp_kwargs])
+    dl_config = DataLoaderConfiguration(split_batches=True)
+    accelerator = Accelerator(cpu=args.cpu, dataloader_config=dl_config, mixed_precision=args.mixed_precision, gradient_accumulation_steps=args.gradient_accumulation_steps, kwargs_handlers=[ddp_kwargs])
     args.device = accelerator.device.type
 
     exp_date = datetime.now().strftime('%y-%m-%d_%H-%M-%S')


### PR DESCRIPTION
Change the original train.py to cope with the following Huggingface PR
https://github.com/huggingface/accelerate/pull/2441
The original code will throw warning and stop running without the fix