### PR TITLE
Fix vqa loss

### DIFF
--- a/gato/tasks/vqa_task.py
+++ b/gato/tasks/vqa_task.py
@@ -91,8 +91,8 @@ class VqaTask(Task):
             answer_idx = random.randint(0, len(item['answers'])-1) # randomly choose an answer out of the set of answers
             batch_dict = {
                 'images': item['image'],
-                # 'text' is to concat the question and a randomly chosen answer with a space in between
-                'text': self.text_tokenizer.encode(item['question'] + ' ' + item['answers'][answer_idx]['answer']) 
+                'text': self.text_tokenizer.encode(item['question']),
+                'vqa_text': self.text_tokenizer.encode(item['answers'][answer_idx]['answer']) 
             }
             batch_dicts.append(batch_dict)
         return batch_dicts

--- a/train.py
+++ b/train.py
@@ -8,6 +8,7 @@ import torch
 from peft import LoraConfig, TaskType, get_peft_model
 from accelerate import Accelerator
 from accelerate import DistributedDataParallelKwargs
+from accelerate import DataLoaderConfiguration
 
 from gato.utils.typed_argparser import TypedArgumentParser
 from gato.training.arguments import TrainingArgs
@@ -23,7 +24,8 @@ from gato.tasks.vqa_task import VqaTask
 
 def main(args):
     ddp_kwargs = DistributedDataParallelKwargs(find_unused_parameters=True)
-    accelerator = Accelerator(cpu=args.cpu, mixed_precision=args.mixed_precision, split_batches=True, gradient_accumulation_steps=args.gradient_accumulation_steps, kwargs_handlers=[ddp_kwargs])
+    dl_config = DataLoaderConfiguration(split_batches=True)
+    accelerator = Accelerator(cpu=args.cpu, dataloader_config=dl_config, mixed_precision=args.mixed_precision, gradient_accumulation_steps=args.gradient_accumulation_steps, kwargs_handlers=[ddp_kwargs])
     args.device = accelerator.device.type
 
     exp_date = datetime.now().strftime('%y-%m-%d_%H-%M-%S')


### PR DESCRIPTION
VQA loss is not decreasing during training, we have tried several ways to reduce it, this is one of the tests.
So far we have been following GATO paper to place all text  (including VQA question and answer) to the left of separator. 
In this PR, we are doing a test to place the question to the left of the separator and place the answer to the right of the separator during training, and see whether that can reduce the VQA loss.

So far, the test has shown that it cannot reduce VQA loss. 

This PR is created to track this issue and solicit code review and see whether we find a solution to reduce the VQA loss 
